### PR TITLE
Fix flag check in add_col method

### DIFF
--- a/pyrivet/hilbert_distance.py
+++ b/pyrivet/hilbert_distance.py
@@ -117,7 +117,7 @@ class SplitMat:
             mat = np.insert(self.mat, 0, [0], axis=1)
             # print("After:")
             # print(mat)
-        elif col == DimensionQueryResult.HIGH:
+        elif flag == DimensionQueryResult.HIGH:
             # print("HIGH")
             mat = np.append(self.mat, np.zeros((self.mat.shape[0], 1)), axis=1)
         elif not self.dimensions[1].is_bound(first_length):


### PR DESCRIPTION
**Current behavior:**
- `add_col` method uses the `col` variable as opposed to `flag` when checking the `DimensionQueryResult.HIGH` case. This means that zero-padding is never executed, and `High` columns are inserted instead

**Fix:**
- Change `col` to `flag`